### PR TITLE
Do not replace inside the files

### DIFF
--- a/co.codewizards.svndumptransformer/src/main/java/co/codewizards/svndumptransformer/SvnDumpTransformer.java
+++ b/co.codewizards.svndumptransformer/src/main/java/co/codewizards/svndumptransformer/SvnDumpTransformer.java
@@ -134,7 +134,7 @@ public class SvnDumpTransformer {
 					TextContent newTextContent = null;
 					if (textContent != null) {
 						newTextContent = textContent.clone();
-						transformTextContent(contentHeader, newContentHeader, propContent, newPropContent, textContent, newTextContent);
+//						transformTextContent(contentHeader, newContentHeader, propContent, newPropContent, textContent, newTextContent);
 					}
 
 					byte[] newPropContentData = null;


### PR DESCRIPTION
Therefore, does not need to know mime types.

This change was triggered by an "Unexpected mime-type: image/x-icon" fatal error while translating some paths. This was done as a hotfix.

Here are some ideas:
* Apparently, the code replaces also *inside* files. If this is so, it should be possible to enable/disable this.
* Replacement should test positively, i.e., for `mimeType.startsWith("text/")` instead of negatively ("is not application/octet-stream").
